### PR TITLE
remove settings interference

### DIFF
--- a/app/views/settings-bbb/_settings.rhtml
+++ b/app/views/settings-bbb/_settings.rhtml
@@ -1,0 +1,26 @@
+This will allow you to use a BigBlueButton server from REDMINE.
+
+<p><label>BigBlueButton server</label>
+<%= text_field_tag 'settings[bbb_server]', @settings['bbb_server'], :size => 80 %><br />
+<em>for example: http://mybbb.domain.com</em>
+</p>
+
+<p><label>Internal address</label>
+<%= text_field_tag 'settings[bbb_ip]', @settings['bbb_ip'], :size => 80 %><br />
+<em>for example: http://192.168.10.1</em>
+</p>
+
+<p><label>salt</label>
+<%= text_field_tag 'settings[bbb_salt]', @settings['bbb_salt'], :size => 80 %><br />
+<em>You'll find it in /var/lib/tomcat6/webapps/bigbluebutton/WEB-INF/classes/bigbluebutton.properties at line beans.dynamicConferenceService.securitySalt=[your_salt]</em>
+</p>
+
+<p><label>return url</label>
+<%= text_field_tag 'settings[bbb_url]', @settings['bbb_url'], :size => 80 %><br />
+<em>url where users will be redirected when exiting the meeting. Leave empty to go back to the previous url (project's overviwe)...</em>
+</p>
+
+<p><label>Use popup window</label>
+<%= check_box_tag 'settings[bbb_popup]', 1, @settings['bbb_popup'] %><br />
+<em>Checked if you want to use a popup window without menu, toolbars, etc... (chat is not allowed in fullscreen mode)</em>
+</p>

--- a/init.rb
+++ b/init.rb
@@ -13,8 +13,8 @@ Redmine::Plugin.register :redmine_bbb do
   description 'Interface with BigBlueButton server'
   version '0.1.0'
 
-  settings :default => {'bbb_server' => ''}, :partial => 'settings/settings'
-  settings :default => {'bbb_salt' => ''}, :partial => 'settings/settings'
+  settings :default => {'bbb_server' => ''}, :partial => 'settings-bbb/settings'
+  settings :default => {'bbb_salt' => ''}, :partial => 'settings-bbb/settings'
   
   project_module :bigbluebutton do
     permission :bigbluebutton_access, :bigbluebutton => :start, :public => true


### PR DESCRIPTION
the folder app/settings is used by other plugins causing the wrong settings partial to be loaded. By renaming it and changing the partial path in redmine-cas.rb this is avoided.
